### PR TITLE
ORC-668. Use `TestSchemaEvolution` as a test file prefix to prevent test failure

### DIFF
--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -700,7 +700,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testTimestampToStringEvolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
                                          testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.fromString("timestamp");
     Writer writer = OrcFile.createWriter(testFilePath,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `TestSchemaEvolution` as a test file prefix to prevent failures during repeated tests.

### Why are the changes needed?

To help the test.

### How was this patch tested?

Repeat the test suite twice.